### PR TITLE
feat: use references in storage 

### DIFF
--- a/storage/src/store/json.rs
+++ b/storage/src/store/json.rs
@@ -125,14 +125,14 @@ where
     }
 
     async fn create(&mut self, item: &T) -> Result<(), StorageError> {
-        self.internal_store.create(&item).await?;
-        self.write_file(&item).await?;
+        self.internal_store.create(item).await?;
+        self.write_file(item).await?;
         Ok(())
     }
 
     async fn update(&mut self, item: &T) -> Result<(), StorageError> {
-        self.internal_store.update(&item).await?;
-        self.write_file(&item).await?;
+        self.internal_store.update(item).await?;
+        self.write_file(item).await?;
         Ok(())
     }
 

--- a/storage/src/store/stub.rs
+++ b/storage/src/store/stub.rs
@@ -44,23 +44,23 @@ where
         Ok(results)
     }
 
-    async fn create(&mut self, item: T) -> Result<(), StorageError> {
+    async fn create(&mut self, item: &T) -> Result<(), StorageError> {
         // Todo: join these futures
         if self.get_by_id(item.get_id()).await.is_ok() {
             return Err(StorageError::AlreadyExists);
         }
-        self.store.push(item);
+        self.store.push(item.clone());
         Ok(())
     }
 
-    async fn update(&mut self, item: T) -> Result<(), StorageError> {
+    async fn update(&mut self, item: &T) -> Result<(), StorageError> {
         let role = self
             .store
             .iter_mut()
             .find(|role| role.get_id() == item.get_id())
             .ok_or(StorageError::NotFound)?;
 
-        *role = item;
+        *role = item.clone();
 
         Ok(())
     }

--- a/storage/src/stores/stub_stores.rs
+++ b/storage/src/stores/stub_stores.rs
@@ -40,11 +40,7 @@ mod tests {
         let mut stores = StubStores::new();
 
         let company = Company::new("Test Company".to_string());
-        stores
-            .company_store()
-            .create(company.clone())
-            .await
-            .unwrap();
+        stores.company_store().create(&company).await.unwrap();
         assert_eq!(
             stores
                 .company_store()
@@ -60,7 +56,7 @@ mod tests {
         let mut stores = StubStores::new();
 
         let role = Role::new(Uuid::new_v4(), "Test Role".to_string(), Timestamp::now());
-        stores.role_store().create(role.clone()).await.unwrap();
+        stores.role_store().create(&role).await.unwrap();
         assert_eq!(
             stores.role_store().get_by_id(role.get_id()).await.unwrap(),
             role
@@ -72,7 +68,7 @@ mod tests {
         let mut stores = StubStores::new();
 
         let flag = Flag::new_green(Uuid::new_v4(), "Test Flag".to_string());
-        stores.flag_store().create(flag.clone()).await.unwrap();
+        stores.flag_store().create(&flag).await.unwrap();
         assert_eq!(
             stores.flag_store().get_by_id(flag.get_id()).await.unwrap(),
             flag

--- a/ui/src/company_list/mod.rs
+++ b/ui/src/company_list/mod.rs
@@ -61,7 +61,7 @@ pub fn CompanyList() -> Element {
                     let mut stores_lock = stores.lock().await;
                     let store_result = stores_lock
                         .company_store()
-                        .create(Company::new(company_name))
+                        .create(&Company::new(company_name))
                         .await;
 
                     match store_result {

--- a/ui/src/flag_list/populated_flag_list.rs
+++ b/ui/src/flag_list/populated_flag_list.rs
@@ -66,7 +66,7 @@ pub fn PopulatedFlagList(company_id: Uuid) -> Element {
                         FlagColor::Red => Flag::new_red(company_id, flag_name),
                     };
 
-                    let result = stores_lock.flag_store().create(flag).await;
+                    let result = stores_lock.flag_store().create(&flag).await;
 
                     match result {
                         Ok(_) => {

--- a/ui/src/role_information/mod.rs
+++ b/ui/src/role_information/mod.rs
@@ -39,7 +39,7 @@ fn PopulatedRoleDescription(role: Role) -> Element {
 
                     role.set_description(role_description.clone());
                     tracing::info!("Role set to {:?}", role);
-                    let result = stores_lock.role_store().update(role).await;
+                    let result = stores_lock.role_store().update(&role).await;
 
                     match result {
                         Ok(_) => {

--- a/ui/src/role_list/populated_role_list.rs
+++ b/ui/src/role_list/populated_role_list.rs
@@ -57,7 +57,7 @@ pub fn PopulatedRoleList(company_id: Uuid) -> Element {
                     let mut stores_lock = stores.lock().await;
                     let result = stores_lock
                         .role_store()
-                        .create(Role::new(company_id, role_name, Timestamp::now()))
+                        .create(&Role::new(company_id, role_name, Timestamp::now()))
                         .await;
 
                     match result {


### PR DESCRIPTION
The only time we need ownership in storage is when inserting or updating the vec in StubStore

Other than that we should stick to using references which will avoid clones outside of the encapsulate store code that only needs to happen when necessary in stubstore.