### PR TITLE
Allow storage of Questions, Interviews, Values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ dev:
 		dx serve --package job-tracker
 
 pre-commit:
-	cargo fmt --check
 	cargo check
 	cargo build
-	cargo clippy
 	cargo test
+	cargo fmt --check
+	cargo clippy -- -D warnings
 	dx fmt --check

--- a/storage/src/application_context/mod.rs
+++ b/storage/src/application_context/mod.rs
@@ -68,16 +68,10 @@ mod tests {
     #[test]
     fn test_new() {
         let context = ApplicationContext::new();
-        assert_eq!(
-            context.get_company(),
-            None,
-            "Initial company value must not be set"
-        );
-        assert_eq!(
-            context.get_role(),
-            None,
-            "Initial role value must not be set"
-        );
+        // Initial company value must not be set
+        assert_eq!(context.get_company(), None,);
+        // Initial role value must not be set
+        assert_eq!(context.get_role(), None,);
     }
     #[tokio::test]
     async fn test_set_get_unset_company_id() {

--- a/storage/src/application_context/mod.rs
+++ b/storage/src/application_context/mod.rs
@@ -1,5 +1,4 @@
-use crate::prelude::Company;
-use crate::storable::Role;
+use crate::storable::{Company, Role};
 use std::sync::Arc;
 use thiserror::Error;
 

--- a/storage/src/composite_store/property/has_future_store.rs
+++ b/storage/src/composite_store/property/has_future_store.rs
@@ -1,5 +1,5 @@
-use crate::storable::{HasCompany, HasDeleted, HasId, HasName};
-use crate::storage::{BaseStore, RecallByCompany, RecallById, RecallByName};
+use crate::storable::{HasCompany, HasDeleted, HasId, HasName, HasRole};
+use crate::storage::{BaseStore, RecallByCompany, RecallById, RecallByName, RecallByRole};
 use crate::Sealed;
 use tokio::sync::MutexGuard;
 
@@ -52,5 +52,16 @@ where
 {
     async fn recall_by_company<I: HasId>(&self, company_id: I) -> anyhow::Result<Vec<O>> {
         self.get_store().await.recall_by_company(company_id).await
+    }
+}
+
+impl<T, O> RecallByRole<O> for T
+where
+    T: HasFutureStoreFor<O>,
+    T::Storage: RecallByRole<O>,
+    O: HasRole + HasDeleted + Clone,
+{
+    async fn recall_by_role<I: HasId>(&self, role: I) -> anyhow::Result<Vec<O>> {
+        self.get_store().await.recall_by_role(role).await
     }
 }

--- a/storage/src/composite_store/store/json_thread_safe_general_store.rs
+++ b/storage/src/composite_store/store/json_thread_safe_general_store.rs
@@ -1,6 +1,6 @@
 use crate::composite_store::ThreadSafeGeneralStore;
 use crate::prelude::Value;
-use crate::storable::{Company, Flag, Question, Role};
+use crate::storable::{Company, Flag, Interview, Question, Role};
 use crate::storage::{JsonStore, ScopedJsonStoreFor};
 use anyhow::Result;
 use std::path::PathBuf;
@@ -11,16 +11,18 @@ pub type JsonThreadSafeGeneralStore = ThreadSafeGeneralStore<
     JsonStore<Flag>,
     JsonStore<Value>,
     JsonStore<Role>,
+    JsonStore<Interview>,
     JsonStore<Question>,
 >;
 
 impl JsonThreadSafeGeneralStore {
     pub async fn new_json(base_path: PathBuf) -> Result<Self> {
-        let (company_store, flag_store, value_store, role_store, question_store) = join!(
+        let (company_store, flag_store, value_store, role_store, interview_store, question_store) = join!(
             JsonStore::<Company>::new_scoped(base_path.clone()),
             JsonStore::<Flag>::new_scoped(base_path.clone()),
             JsonStore::<Value>::new_scoped(base_path.clone()),
             JsonStore::<Role>::new_scoped(base_path.clone()),
+            JsonStore::<Interview>::new_scoped(base_path.clone()),
             JsonStore::<Question>::new_scoped(base_path.clone()),
         );
 
@@ -29,6 +31,7 @@ impl JsonThreadSafeGeneralStore {
             flag_store?,
             value_store?,
             role_store?,
+            interview_store?,
             question_store?,
         ))
     }

--- a/storage/src/composite_store/store/json_thread_safe_general_store.rs
+++ b/storage/src/composite_store/store/json_thread_safe_general_store.rs
@@ -1,4 +1,5 @@
 use crate::composite_store::ThreadSafeGeneralStore;
+use crate::prelude::Value;
 use crate::storable::{Company, Flag, Question, Role};
 use crate::storage::{JsonStore, ScopedJsonStoreFor};
 use anyhow::Result;
@@ -8,15 +9,17 @@ use tokio::join;
 pub type JsonThreadSafeGeneralStore = ThreadSafeGeneralStore<
     JsonStore<Company>,
     JsonStore<Flag>,
+    JsonStore<Value>,
     JsonStore<Role>,
     JsonStore<Question>,
 >;
 
 impl JsonThreadSafeGeneralStore {
     pub async fn new_json(base_path: PathBuf) -> Result<Self> {
-        let (company_store, flag_store, role_store, question_store) = join!(
+        let (company_store, flag_store, value_store, role_store, question_store) = join!(
             JsonStore::<Company>::new_scoped(base_path.clone()),
             JsonStore::<Flag>::new_scoped(base_path.clone()),
+            JsonStore::<Value>::new_scoped(base_path.clone()),
             JsonStore::<Role>::new_scoped(base_path.clone()),
             JsonStore::<Question>::new_scoped(base_path.clone()),
         );
@@ -24,6 +27,7 @@ impl JsonThreadSafeGeneralStore {
         Ok(Self::new(
             company_store?,
             flag_store?,
+            value_store?,
             role_store?,
             question_store?,
         ))

--- a/storage/src/composite_store/store/json_thread_safe_general_store.rs
+++ b/storage/src/composite_store/store/json_thread_safe_general_store.rs
@@ -1,22 +1,32 @@
 use crate::composite_store::ThreadSafeGeneralStore;
-use crate::storable::{Company, Flag, Role};
+use crate::storable::{Company, Flag, Question, Role};
 use crate::storage::{JsonStore, ScopedJsonStoreFor};
 use anyhow::Result;
 use std::path::PathBuf;
 use tokio::join;
 
-pub type JsonThreadSafeGeneralStore =
-    ThreadSafeGeneralStore<JsonStore<Company>, JsonStore<Flag>, JsonStore<Role>>;
+pub type JsonThreadSafeGeneralStore = ThreadSafeGeneralStore<
+    JsonStore<Company>,
+    JsonStore<Flag>,
+    JsonStore<Role>,
+    JsonStore<Question>,
+>;
 
 impl JsonThreadSafeGeneralStore {
     pub async fn new_json(base_path: PathBuf) -> Result<Self> {
-        let (company_store, flag_store, role_store) = join!(
+        let (company_store, flag_store, role_store, question_store) = join!(
             JsonStore::<Company>::new_scoped(base_path.clone()),
             JsonStore::<Flag>::new_scoped(base_path.clone()),
             JsonStore::<Role>::new_scoped(base_path.clone()),
+            JsonStore::<Question>::new_scoped(base_path.clone()),
         );
 
-        Ok(Self::new(company_store?, flag_store?, role_store?))
+        Ok(Self::new(
+            company_store?,
+            flag_store?,
+            role_store?,
+            question_store?,
+        ))
     }
 }
 

--- a/storage/src/composite_store/store/thread_safe_general_store.rs
+++ b/storage/src/composite_store/store/thread_safe_general_store.rs
@@ -1,8 +1,6 @@
 use crate::composite_store::HasFutureStoreFor;
-use crate::storable::{Company, Flag, Interview, Question, Role, Value};
-use crate::storage::{
-    CompanyStore, FlagStore, InterviewStore, QuestionStore, RoleStore, ValueStore,
-};
+use crate::storable::*;
+use crate::storage::*;
 use crate::Sealed;
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
@@ -237,16 +235,12 @@ mod test_helper {
 
 #[cfg(test)]
 mod tests {
-    use crate::composite_store::ThreadSafeGeneralStore;
-    use crate::storable::*;
-    use crate::storage::{
-        recall_by_company::test_helper::test_recall_by_company,
-        recall_by_id::test_helper::test_recall_by_id,
-        recall_by_name::test_helper::test_recall_by_name,
-        recall_by_role::test_helper::test_recall_by_role, *,
-    };
+    use super::*;
     use crate::test_helper::*;
-    use crate::Timestamp;
+    use crate::{
+        test_recall_by_company, test_recall_by_id, test_recall_by_name, test_recall_by_role,
+        Timestamp,
+    };
     use paste::paste;
 
     test_recall_by_id!(ThreadSafeGeneralStore, Company);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -34,8 +34,8 @@ pub mod prelude {
     pub use crate::error::StorageError;
     pub use crate::logging::{json_log_fetcher::JsonLogFetcher, LogFetcher};
     pub use crate::storable::{
-        Company, Flag, FlagColor, HasCompany, HasDeleted, HasId, HasName, HasRole, Question, Role,
-        Value,
+        Company, Flag, FlagColor, HasCompany, HasDeleted, HasId, HasName, HasRole, Interview,
+        Question, Role, Value,
     };
     pub use crate::storage::{
         BaseStore, CompanyStore, FlagStore, JsonStore, RecallByCompany, RecallById, RecallByName,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -35,6 +35,7 @@ pub mod prelude {
     pub use crate::logging::{json_log_fetcher::JsonLogFetcher, LogFetcher};
     pub use crate::storable::{
         Company, Flag, FlagColor, HasCompany, HasDeleted, HasId, HasName, HasRole, Question, Role,
+        Value,
     };
     pub use crate::storage::{
         BaseStore, CompanyStore, FlagStore, JsonStore, RecallByCompany, RecallById, RecallByName,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -34,11 +34,11 @@ pub mod prelude {
     pub use crate::error::StorageError;
     pub use crate::logging::{json_log_fetcher::JsonLogFetcher, LogFetcher};
     pub use crate::storable::{
-        Company, Flag, FlagColor, HasCompany, HasDeleted, HasId, HasName, Role,
+        Company, Flag, FlagColor, HasCompany, HasDeleted, HasId, HasName, HasRole, Question, Role,
     };
     pub use crate::storage::{
         BaseStore, CompanyStore, FlagStore, JsonStore, RecallByCompany, RecallById, RecallByName,
-        RoleStore, ScopedJsonStoreFor,
+        RecallByRole, RoleStore, ScopedJsonStoreFor,
     };
     pub use crate::time::Timestamp;
 }

--- a/storage/src/storable/object/company.rs
+++ b/storage/src/storable/object/company.rs
@@ -1,5 +1,5 @@
 use crate::storable::{Flag, HasDeleted, HasId, HasName, Role};
-use crate::Timestamp;
+use crate::{impl_has_deleted, impl_has_id, impl_has_name, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -38,23 +38,9 @@ impl PartialEq for Company {
     }
 }
 
-impl HasId for Company {
-    fn get_id(&self) -> Uuid {
-        self.id
-    }
-}
-
-impl HasName for Company {
-    fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
-impl HasDeleted for Company {
-    fn is_deleted(&self) -> bool {
-        self.date_deleted.is_some()
-    }
-}
+impl_has_id!(Company);
+impl_has_name!(Company);
+impl_has_deleted!(Company);
 
 #[cfg(test)]
 mod test_helper {

--- a/storage/src/storable/object/company.rs
+++ b/storage/src/storable/object/company.rs
@@ -57,11 +57,9 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storable::{
-        has_deleted::test_helper::test_has_deleted, has_id::test_helper::test_has_id,
-        has_name::test_helper::test_has_name, HasCompany,
-    };
+    use crate::storable::HasCompany;
     use crate::test_helper::TestHelper;
+    use crate::{test_has_deleted, test_has_id, test_has_name};
     use paste::paste;
 
     test_has_id!(Company);

--- a/storage/src/storable/object/company.rs
+++ b/storage/src/storable/object/company.rs
@@ -20,15 +20,15 @@ impl Company {
     }
 
     pub fn create_role<S: Into<String>>(&self, name: S, date_created: Timestamp) -> Role {
-        Role::new(self.id, name, date_created)
+        Role::new(self, name, date_created)
     }
 
     pub fn create_green_flag<S: Into<String>>(&self, name: S) -> Flag {
-        Flag::new_green(self.id, name)
+        Flag::new_green(self, name)
     }
 
     pub fn create_red_flag<S: Into<String>>(&self, name: S) -> Flag {
-        Flag::new_red(self.id, name)
+        Flag::new_red(self, name)
     }
 }
 

--- a/storage/src/storable/object/flag.rs
+++ b/storage/src/storable/object/flag.rs
@@ -81,11 +81,8 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storable::{
-        has_company::test_helper::test_has_company, has_deleted::test_helper::test_has_deleted,
-        has_id::test_helper::test_has_id, has_name::test_helper::test_has_name,
-    };
     use crate::test_helper::TestHelper;
+    use crate::{test_has_company, test_has_deleted, test_has_id, test_has_name};
     use paste::paste;
 
     test_has_id!(Flag);

--- a/storage/src/storable/object/flag.rs
+++ b/storage/src/storable/object/flag.rs
@@ -33,20 +33,20 @@ pub struct Flag {
 }
 
 impl Flag {
-    pub fn new_green<S: Into<String>>(company_id: Uuid, name: S) -> Self {
+    pub fn new_green<C: HasId, S: Into<String>>(company: C, name: S) -> Self {
         Flag {
             id: Uuid::new_v4(),
-            company_id,
+            company_id: company.get_id(),
             flag_color: FlagColor::Green,
             name: name.into(),
             date_deleted: None,
         }
     }
 
-    pub fn new_red<S: Into<String>>(company_id: Uuid, name: S) -> Self {
+    pub fn new_red<C: HasId, S: Into<String>>(company: C, name: S) -> Self {
         Flag {
             id: Uuid::new_v4(),
-            company_id,
+            company_id: company.get_id(),
             flag_color: FlagColor::Red,
             name: name.into(),
             date_deleted: None,

--- a/storage/src/storable/object/flag.rs
+++ b/storage/src/storable/object/flag.rs
@@ -1,5 +1,5 @@
 use crate::storable::{HasCompany, HasDeleted, HasId, HasName};
-use crate::Timestamp;
+use crate::{impl_has_company, impl_has_deleted, impl_has_id, impl_has_name, Timestamp};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use uuid::Uuid;
@@ -60,29 +60,10 @@ impl PartialEq for Flag {
     }
 }
 
-impl HasName for Flag {
-    fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
-impl HasId for Flag {
-    fn get_id(&self) -> Uuid {
-        self.id
-    }
-}
-
-impl HasDeleted for Flag {
-    fn is_deleted(&self) -> bool {
-        self.date_deleted.is_some()
-    }
-}
-
-impl HasCompany for Flag {
-    fn get_company_id(&self) -> Uuid {
-        self.company_id
-    }
-}
+impl_has_id!(Flag);
+impl_has_name!(Flag);
+impl_has_company!(Flag);
+impl_has_deleted!(Flag);
 
 #[cfg(test)]
 mod test_helper {

--- a/storage/src/storable/object/flag.rs
+++ b/storage/src/storable/object/flag.rs
@@ -56,7 +56,7 @@ impl Flag {
 
 impl PartialEq for Flag {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.id == other.id && self.company_id == other.company_id
     }
 }
 

--- a/storage/src/storable/object/interview.rs
+++ b/storage/src/storable/object/interview.rs
@@ -1,0 +1,69 @@
+use crate::storable::*;
+use crate::{impl_has_deleted, impl_has_id, impl_has_name, impl_has_role, Timestamp};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Interview {
+    pub id: Uuid,
+    pub role_id: Uuid,
+    pub name: String,
+    pub notes: String,
+    pub host: Vec<String>,
+    pub date_time: Option<Timestamp>,
+    pub date_deleted: Option<Timestamp>,
+}
+
+impl Interview {
+    pub fn new<S: Into<String>>(role_id: Uuid, name: S) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            role_id,
+            name: name.into(),
+            notes: String::new(),
+            host: Vec::with_capacity(0),
+            date_time: None,
+            date_deleted: None,
+        }
+    }
+}
+
+impl PartialEq for Interview {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.role_id == other.role_id
+    }
+}
+
+impl_has_id!(Interview);
+impl_has_name!(Interview);
+impl_has_role!(Interview);
+impl_has_deleted!(Interview);
+
+#[cfg(test)]
+mod test_helper {
+    use super::*;
+    use crate::test_helper::TestHelper;
+    use uuid::Uuid;
+
+    impl TestHelper for Interview {
+        async fn new_test() -> anyhow::Result<Self> {
+            Ok(Interview::new(Uuid::new_v4(), "Interview"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storable::{
+        has_deleted::test_helper::test_has_deleted, has_id::test_helper::test_has_id,
+        has_name::test_helper::test_has_name, has_role::test_helper::test_has_role,
+    };
+    use crate::test_helper::TestHelper;
+    use paste::paste;
+
+    test_has_id!(Interview);
+    test_has_name!(Interview);
+    test_has_role!(Interview);
+    test_has_deleted!(Interview);
+}

--- a/storage/src/storable/object/interview.rs
+++ b/storage/src/storable/object/interview.rs
@@ -15,10 +15,10 @@ pub struct Interview {
 }
 
 impl Interview {
-    pub fn new<S: Into<String>>(role_id: Uuid, name: S) -> Self {
+    pub fn new<R: HasId, S: Into<String>>(role: R, name: S) -> Self {
         Self {
             id: Uuid::new_v4(),
-            role_id,
+            role_id: role.get_id(),
             name: name.into(),
             notes: String::new(),
             host: Vec::with_capacity(0),

--- a/storage/src/storable/object/interview.rs
+++ b/storage/src/storable/object/interview.rs
@@ -55,11 +55,8 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storable::{
-        has_deleted::test_helper::test_has_deleted, has_id::test_helper::test_has_id,
-        has_name::test_helper::test_has_name, has_role::test_helper::test_has_role,
-    };
     use crate::test_helper::TestHelper;
+    use crate::{test_has_deleted, test_has_id, test_has_name, test_has_role};
     use paste::paste;
 
     test_has_id!(Interview);

--- a/storage/src/storable/object/mod.rs
+++ b/storage/src/storable/object/mod.rs
@@ -10,5 +10,8 @@ pub use role::*;
 mod question;
 pub use question::*;
 
+mod interview;
+pub use interview::*;
+
 mod value;
 pub use value::*;

--- a/storage/src/storable/object/mod.rs
+++ b/storage/src/storable/object/mod.rs
@@ -6,3 +6,6 @@ pub use flag::*;
 
 mod role;
 pub use role::*;
+
+mod question;
+pub use question::*;

--- a/storage/src/storable/object/mod.rs
+++ b/storage/src/storable/object/mod.rs
@@ -9,3 +9,6 @@ pub use role::*;
 
 mod question;
 pub use question::*;
+
+mod value;
+pub use value::*;

--- a/storage/src/storable/object/question.rs
+++ b/storage/src/storable/object/question.rs
@@ -13,10 +13,10 @@ pub struct Question {
 }
 
 impl Question {
-    pub fn new<S: Into<String>>(role_id: Uuid, name: S) -> Self {
+    pub fn new<R: HasId, S: Into<String>>(role: R, name: S) -> Self {
         Self {
             id: Uuid::new_v4(),
-            role_id,
+            role_id: role.get_id(),
             name: name.into(),
             answer: "".to_string(),
             date_deleted: None,

--- a/storage/src/storable/object/question.rs
+++ b/storage/src/storable/object/question.rs
@@ -51,11 +51,8 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storable::{
-        has_deleted::test_helper::test_has_deleted, has_id::test_helper::test_has_id,
-        has_name::test_helper::test_has_name, has_role::test_helper::test_has_role,
-    };
     use crate::test_helper::TestHelper;
+    use crate::{test_has_deleted, test_has_id, test_has_name, test_has_role};
     use paste::paste;
 
     test_has_id!(Question);

--- a/storage/src/storable/object/question.rs
+++ b/storage/src/storable/object/question.rs
@@ -1,5 +1,4 @@
-use crate::prelude::{HasDeleted, HasId, HasName};
-use crate::storable::HasRole;
+use crate::storable::*;
 use crate::{impl_has_role, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/storage/src/storable/object/question.rs
+++ b/storage/src/storable/object/question.rs
@@ -1,0 +1,81 @@
+use crate::prelude::{HasDeleted, HasId, HasName};
+use crate::storable::HasRole;
+use crate::{impl_has_role, Timestamp};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Question {
+    pub id: Uuid,
+    pub role_id: Uuid,
+    pub name: String,
+    pub answer: String,
+    pub date_deleted: Option<Timestamp>,
+}
+
+impl Question {
+    pub fn new<S: Into<String>>(role_id: Uuid, name: S) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            role_id,
+            name: name.into(),
+            answer: "".to_string(),
+            date_deleted: None,
+        }
+    }
+}
+
+impl PartialEq for Question {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.role_id == other.role_id
+    }
+}
+
+impl HasId for Question {
+    fn get_id(&self) -> Uuid {
+        self.id
+    }
+}
+
+impl HasName for Question {
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl HasDeleted for Question {
+    fn is_deleted(&self) -> bool {
+        self.date_deleted.is_some()
+    }
+}
+
+impl_has_role!(Question);
+
+#[cfg(test)]
+mod test_helper {
+    use super::*;
+    use crate::test_helper::TestHelper;
+    use uuid::Uuid;
+
+    impl TestHelper for Question {
+        async fn new_test() -> anyhow::Result<Self> {
+            Ok(Question::new(Uuid::new_v4(), "Question"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storable::{
+        has_deleted::test_helper::test_has_deleted, has_id::test_helper::test_has_id,
+        has_name::test_helper::test_has_name, has_role::test_helper::test_has_role,
+    };
+    use crate::test_helper::TestHelper;
+    use paste::paste;
+
+    test_has_id!(Question);
+    test_has_name!(Question);
+    test_has_role!(Question);
+    test_has_deleted!(Question);
+}

--- a/storage/src/storable/object/question.rs
+++ b/storage/src/storable/object/question.rs
@@ -1,5 +1,5 @@
 use crate::storable::*;
-use crate::{impl_has_role, Timestamp};
+use crate::{impl_has_deleted, impl_has_id, impl_has_name, impl_has_role, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -30,25 +30,10 @@ impl PartialEq for Question {
     }
 }
 
-impl HasId for Question {
-    fn get_id(&self) -> Uuid {
-        self.id
-    }
-}
-
-impl HasName for Question {
-    fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
-impl HasDeleted for Question {
-    fn is_deleted(&self) -> bool {
-        self.date_deleted.is_some()
-    }
-}
-
+impl_has_id!(Question);
+impl_has_name!(Question);
 impl_has_role!(Question);
+impl_has_deleted!(Question);
 
 #[cfg(test)]
 mod test_helper {

--- a/storage/src/storable/object/role.rs
+++ b/storage/src/storable/object/role.rs
@@ -68,6 +68,7 @@ mod test_helper {
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/storage/src/storable/object/role.rs
+++ b/storage/src/storable/object/role.rs
@@ -1,4 +1,4 @@
-use crate::storable::{HasCompany, HasDeleted, HasId, HasName};
+use crate::storable::{HasCompany, HasDeleted, HasId, HasName, Question};
 use crate::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -23,6 +23,10 @@ impl Role {
             date_applied,
             date_deleted: None,
         }
+    }
+
+    pub fn create_question<S: Into<String>>(&self, name: S) -> Question {
+        Question::new(self.id, name)
     }
 }
 
@@ -83,4 +87,12 @@ mod tests {
     test_has_name!(Role);
     test_has_company!(Role);
     test_has_deleted!(Role);
+
+    #[test]
+    fn test_create_question() {
+        let role = Role::new(Uuid::new_v4(), "role", Timestamp::now());
+        let question = role.create_question("question");
+        assert_eq!(question.role_id, role.id);
+        assert_eq!(question.name, "question");
+    }
 }

--- a/storage/src/storable/object/role.rs
+++ b/storage/src/storable/object/role.rs
@@ -62,11 +62,8 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storable::{
-        has_company::test_helper::test_has_company, has_deleted::test_helper::test_has_deleted,
-        has_id::test_helper::test_has_id, has_name::test_helper::test_has_name,
-    };
     use crate::test_helper::TestHelper;
+    use crate::{test_has_company, test_has_deleted, test_has_id, test_has_name};
     use paste::paste;
 
     test_has_id!(Role);

--- a/storage/src/storable/object/role.rs
+++ b/storage/src/storable/object/role.rs
@@ -1,3 +1,4 @@
+use crate::prelude::Interview;
 use crate::storable::{HasCompany, HasDeleted, HasId, HasName, Question};
 use crate::{impl_has_company, impl_has_deleted, impl_has_id, impl_has_name, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -14,10 +15,10 @@ pub struct Role {
 }
 
 impl Role {
-    pub fn new<S: Into<String>>(company_id: Uuid, name: S, date_applied: Timestamp) -> Role {
+    pub fn new<C: HasId, S: Into<String>>(company: C, name: S, date_applied: Timestamp) -> Role {
         Role {
             id: Uuid::new_v4(),
-            company_id,
+            company_id: company.get_id(),
             name: name.into(),
             description: "".to_string(),
             date_applied,
@@ -26,7 +27,11 @@ impl Role {
     }
 
     pub fn create_question<S: Into<String>>(&self, name: S) -> Question {
-        Question::new(self.id, name)
+        Question::new(self, name)
+    }
+
+    pub fn create_interview<S: Into<String>>(&self, name: S) -> Interview {
+        Interview::new(self, name)
     }
 }
 
@@ -75,5 +80,13 @@ mod tests {
         let question = role.create_question("question");
         assert_eq!(question.role_id, role.id);
         assert_eq!(question.name, "question");
+    }
+
+    #[test]
+    fn test_create_interview() {
+        let role = Role::new(Uuid::new_v4(), "role", Timestamp::now());
+        let interview = role.create_interview("interview");
+        assert_eq!(interview.role_id, role.id);
+        assert_eq!(interview.name, "interview");
     }
 }

--- a/storage/src/storable/object/role.rs
+++ b/storage/src/storable/object/role.rs
@@ -37,7 +37,7 @@ impl Role {
 
 impl PartialEq for Role {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.name == other.name && self.company_id == other.company_id
+        self.id == other.id && self.company_id == other.company_id
     }
 }
 

--- a/storage/src/storable/object/role.rs
+++ b/storage/src/storable/object/role.rs
@@ -1,5 +1,5 @@
 use crate::storable::{HasCompany, HasDeleted, HasId, HasName, Question};
-use crate::Timestamp;
+use crate::{impl_has_company, impl_has_deleted, impl_has_id, impl_has_name, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -36,29 +36,10 @@ impl PartialEq for Role {
     }
 }
 
-impl HasId for Role {
-    fn get_id(&self) -> Uuid {
-        self.id
-    }
-}
-
-impl HasCompany for Role {
-    fn get_company_id(&self) -> Uuid {
-        self.company_id
-    }
-}
-
-impl HasName for Role {
-    fn get_name(&self) -> &str {
-        &self.name
-    }
-}
-
-impl HasDeleted for Role {
-    fn is_deleted(&self) -> bool {
-        self.date_deleted.is_some()
-    }
-}
+impl_has_id!(Role);
+impl_has_name!(Role);
+impl_has_company!(Role);
+impl_has_deleted!(Role);
 
 #[cfg(test)]
 mod test_helper {

--- a/storage/src/storable/object/value.rs
+++ b/storage/src/storable/object/value.rs
@@ -1,0 +1,57 @@
+use crate::storable::*;
+use crate::{impl_has_company, impl_has_deleted, impl_has_id, impl_has_name, Timestamp};
+use uuid::Uuid;
+
+pub struct Value {
+    pub id: Uuid,
+    pub company_id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub date_deleted: Option<Timestamp>,
+}
+
+impl Value {
+    pub fn new<C: HasId, S: Into<String>>(company_id: C, name: S) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            company_id: company_id.get_id(),
+            name: name.into(),
+            description: "".to_string(),
+            date_deleted: None,
+        }
+    }
+}
+
+impl_has_id!(Value);
+impl_has_name!(Value);
+impl_has_company!(Value);
+impl_has_deleted!(Value);
+
+#[cfg(test)]
+mod test_helper {
+    use super::*;
+    use crate::test_helper::TestHelper;
+    use uuid::Uuid;
+
+    impl TestHelper for Value {
+        async fn new_test() -> anyhow::Result<Self> {
+            Ok(Value::new(Uuid::new_v4(), "Value"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storable::{
+        has_company::test_helper::test_has_company, has_deleted::test_helper::test_has_deleted,
+        has_id::test_helper::test_has_id, has_name::test_helper::test_has_name,
+    };
+    use crate::test_helper::TestHelper;
+    use paste::paste;
+
+    test_has_id!(Value);
+    test_has_name!(Value);
+    test_has_company!(Value);
+    test_has_deleted!(Value);
+}

--- a/storage/src/storable/object/value.rs
+++ b/storage/src/storable/object/value.rs
@@ -51,11 +51,8 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storable::{
-        has_company::test_helper::test_has_company, has_deleted::test_helper::test_has_deleted,
-        has_id::test_helper::test_has_id, has_name::test_helper::test_has_name,
-    };
     use crate::test_helper::TestHelper;
+    use crate::{test_has_company, test_has_deleted, test_has_id, test_has_name};
     use paste::paste;
 
     test_has_id!(Value);

--- a/storage/src/storable/object/value.rs
+++ b/storage/src/storable/object/value.rs
@@ -13,10 +13,10 @@ pub struct Value {
 }
 
 impl Value {
-    pub fn new<C: HasId, S: Into<String>>(company_id: C, name: S) -> Self {
+    pub fn new<C: HasId, S: Into<String>>(company: C, name: S) -> Self {
         Self {
             id: Uuid::new_v4(),
-            company_id: company_id.get_id(),
+            company_id: company.get_id(),
             name: name.into(),
             description: "".to_string(),
             date_deleted: None,

--- a/storage/src/storable/object/value.rs
+++ b/storage/src/storable/object/value.rs
@@ -1,7 +1,9 @@
 use crate::storable::*;
 use crate::{impl_has_company, impl_has_deleted, impl_has_id, impl_has_name, Timestamp};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Value {
     pub id: Uuid,
     pub company_id: Uuid,
@@ -19,6 +21,12 @@ impl Value {
             description: "".to_string(),
             date_deleted: None,
         }
+    }
+}
+
+impl PartialEq for Value {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.company_id == other.company_id
     }
 }
 

--- a/storage/src/storable/property/has_company.rs
+++ b/storage/src/storable/property/has_company.rs
@@ -26,6 +26,7 @@ macro_rules! impl_has_company {
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_has_company {
         ($storable:ident) => {
             paste! {
@@ -38,6 +39,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_has_company;
 }

--- a/storage/src/storable/property/has_company.rs
+++ b/storage/src/storable/property/has_company.rs
@@ -13,6 +13,17 @@ where
     }
 }
 
+#[macro_export]
+macro_rules! impl_has_company {
+    ($storable:ty) => {
+        impl HasCompany for $storable {
+            fn get_company_id(&self) -> Uuid {
+                self.company_id
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_company {

--- a/storage/src/storable/property/has_deleted.rs
+++ b/storage/src/storable/property/has_deleted.rs
@@ -10,6 +10,17 @@ where
     }
 }
 
+#[macro_export]
+macro_rules! impl_has_deleted {
+    ($storable:ty) => {
+        impl HasDeleted for $storable {
+            fn is_deleted(&self) -> bool {
+                self.date_deleted.is_some()
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_deleted {

--- a/storage/src/storable/property/has_deleted.rs
+++ b/storage/src/storable/property/has_deleted.rs
@@ -23,6 +23,7 @@ macro_rules! impl_has_deleted {
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_has_deleted {
         ($storable:ident) => {
             paste! {
@@ -37,6 +38,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_has_deleted;
 }

--- a/storage/src/storable/property/has_id.rs
+++ b/storage/src/storable/property/has_id.rs
@@ -19,6 +19,17 @@ impl HasId for Uuid {
     }
 }
 
+#[macro_export]
+macro_rules! impl_has_id {
+    ($storable:ty) => {
+        impl HasId for $storable {
+            fn get_id(&self) -> Uuid {
+                self.id
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_id {

--- a/storage/src/storable/property/has_id.rs
+++ b/storage/src/storable/property/has_id.rs
@@ -32,6 +32,7 @@ macro_rules! impl_has_id {
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_has_id {
         ($storable:ident) => {
             paste! {
@@ -44,6 +45,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_has_id;
 }

--- a/storage/src/storable/property/has_name.rs
+++ b/storage/src/storable/property/has_name.rs
@@ -11,6 +11,17 @@ where
     }
 }
 
+#[macro_export]
+macro_rules! impl_has_name {
+    ($storable:ty) => {
+        impl HasName for $storable {
+            fn get_name(&self) -> &str {
+                &self.name
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_name {

--- a/storage/src/storable/property/has_name.rs
+++ b/storage/src/storable/property/has_name.rs
@@ -24,6 +24,7 @@ macro_rules! impl_has_name {
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_has_name {
         ($storable:ident) => {
             paste! {
@@ -35,6 +36,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_has_name;
 }

--- a/storage/src/storable/property/has_role.rs
+++ b/storage/src/storable/property/has_role.rs
@@ -1,0 +1,43 @@
+use uuid::Uuid;
+
+pub trait HasRole {
+    fn get_role_id(&self) -> Uuid;
+}
+
+impl<T> HasRole for &T
+where
+    T: HasRole,
+{
+    fn get_role_id(&self) -> Uuid {
+        (*self).get_role_id()
+    }
+}
+
+#[macro_export]
+macro_rules! impl_has_role {
+    ($storable:ty) => {
+        impl HasRole for $storable {
+            fn get_role_id(&self) -> Uuid {
+                self.role_id
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+pub mod test_helper {
+    macro_rules! test_has_role {
+        ($storable:ident) => {
+            paste! {
+                #[tokio::test]
+                async fn [< test_has_role_ $storable:snake >] () {
+                    let storable = $storable::new_test().await.expect("Could not create storable");
+                    // Not the best test TBH, might break if we stop using v4 uuids
+                    assert_eq!(storable.get_role_id().get_version(), Some(uuid::Version::Random));
+                }
+            }
+        };
+    }
+
+    pub(crate) use test_has_role;
+}

--- a/storage/src/storable/property/has_role.rs
+++ b/storage/src/storable/property/has_role.rs
@@ -26,6 +26,7 @@ macro_rules! impl_has_role {
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_has_role {
         ($storable:ident) => {
             paste! {
@@ -38,6 +39,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_has_role;
 }

--- a/storage/src/storable/property/mod.rs
+++ b/storage/src/storable/property/mod.rs
@@ -1,6 +1,9 @@
 pub mod has_company;
 pub use has_company::HasCompany;
 
+pub mod has_role;
+pub use has_role::HasRole;
+
 pub mod has_deleted;
 pub use has_deleted::HasDeleted;
 

--- a/storage/src/storage/medium/json_storage.rs
+++ b/storage/src/storage/medium/json_storage.rs
@@ -182,13 +182,10 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::property::recall_by_id::test_helper::test_recall_by_id;
-    use crate::storage::recall_by_role::test_helper::test_recall_by_role;
-    use crate::storage::{
-        recall_by_company::test_helper::test_recall_by_company,
-        recall_by_name::test_helper::test_recall_by_name,
-    };
     use crate::test_helper::*;
+    use crate::{
+        test_recall_by_company, test_recall_by_id, test_recall_by_name, test_recall_by_role,
+    };
     use paste::paste;
     use std::fs::File;
     use std::io::Write;

--- a/storage/src/storage/medium/json_storage.rs
+++ b/storage/src/storage/medium/json_storage.rs
@@ -1,9 +1,9 @@
 use crate::storable::{
-    Company, Flag, HasCompany, HasDeleted, HasId, HasName, HasRole, Question, Role,
+    Company, Flag, HasCompany, HasDeleted, HasId, HasName, HasRole, Question, Role, Value,
 };
 use crate::storage::{
     BaseStore, CompanyStore, FlagStore, QuestionStore, RecallByCompany, RecallById, RecallByName,
-    RecallByRole, RoleStore, StubStore,
+    RecallByRole, RoleStore, StubStore, ValueStore,
 };
 use anyhow::Result;
 use serde::de::DeserializeOwned;
@@ -77,6 +77,13 @@ impl ScopedJsonStoreFor for JsonStore<Flag> {
     }
 }
 
+impl ScopedJsonStoreFor for JsonStore<Value> {
+    async fn new_scoped(mut base_path: PathBuf) -> Result<Self> {
+        base_path.push("value");
+        Self::new(base_path).await
+    }
+}
+
 impl ScopedJsonStoreFor for JsonStore<Role> {
     async fn new_scoped(mut base_path: PathBuf) -> Result<Self> {
         base_path.push("role");
@@ -142,6 +149,7 @@ impl CompanyStore for JsonStore<Company> {}
 impl RoleStore for JsonStore<Role> {}
 impl FlagStore for JsonStore<Flag> {}
 impl QuestionStore for JsonStore<Question> {}
+impl ValueStore for JsonStore<Value> {}
 
 #[cfg(test)]
 mod test_helper {
@@ -178,13 +186,16 @@ mod tests {
     test_recall_by_id!(JsonStore, Company);
     test_recall_by_id!(JsonStore, Flag);
     test_recall_by_id!(JsonStore, Role);
+    test_recall_by_id!(JsonStore, Value);
     test_recall_by_id!(JsonStore, Question);
     test_recall_by_name!(JsonStore, Company);
     test_recall_by_name!(JsonStore, Flag);
     test_recall_by_name!(JsonStore, Role);
+    test_recall_by_name!(JsonStore, Value);
     test_recall_by_name!(JsonStore, Question);
     test_recall_by_company!(JsonStore, Flag);
     test_recall_by_company!(JsonStore, Role);
+    test_recall_by_company!(JsonStore, Value);
     test_recall_by_role!(JsonStore, Question);
 
     #[tokio::test]

--- a/storage/src/storage/medium/json_storage.rs
+++ b/storage/src/storage/medium/json_storage.rs
@@ -1,9 +1,10 @@
+use crate::prelude::Interview;
 use crate::storable::{
     Company, Flag, HasCompany, HasDeleted, HasId, HasName, HasRole, Question, Role, Value,
 };
 use crate::storage::{
-    BaseStore, CompanyStore, FlagStore, QuestionStore, RecallByCompany, RecallById, RecallByName,
-    RecallByRole, RoleStore, StubStore, ValueStore,
+    BaseStore, CompanyStore, FlagStore, InterviewStore, QuestionStore, RecallByCompany, RecallById,
+    RecallByName, RecallByRole, RoleStore, StubStore, ValueStore,
 };
 use anyhow::Result;
 use serde::de::DeserializeOwned;
@@ -91,6 +92,13 @@ impl ScopedJsonStoreFor for JsonStore<Role> {
     }
 }
 
+impl ScopedJsonStoreFor for JsonStore<Interview> {
+    async fn new_scoped(mut base_path: PathBuf) -> Result<Self> {
+        base_path.push("interview");
+        Self::new(base_path).await
+    }
+}
+
 impl ScopedJsonStoreFor for JsonStore<Question> {
     async fn new_scoped(mut base_path: PathBuf) -> Result<Self> {
         base_path.push("question");
@@ -149,6 +157,8 @@ impl CompanyStore for JsonStore<Company> {}
 impl RoleStore for JsonStore<Role> {}
 impl FlagStore for JsonStore<Flag> {}
 impl QuestionStore for JsonStore<Question> {}
+impl InterviewStore for JsonStore<Interview> {}
+
 impl ValueStore for JsonStore<Value> {}
 
 #[cfg(test)]
@@ -188,15 +198,18 @@ mod tests {
     test_recall_by_id!(JsonStore, Role);
     test_recall_by_id!(JsonStore, Value);
     test_recall_by_id!(JsonStore, Question);
+    test_recall_by_id!(JsonStore, Interview);
     test_recall_by_name!(JsonStore, Company);
     test_recall_by_name!(JsonStore, Flag);
     test_recall_by_name!(JsonStore, Role);
     test_recall_by_name!(JsonStore, Value);
     test_recall_by_name!(JsonStore, Question);
+    test_recall_by_name!(JsonStore, Interview);
     test_recall_by_company!(JsonStore, Flag);
     test_recall_by_company!(JsonStore, Role);
     test_recall_by_company!(JsonStore, Value);
     test_recall_by_role!(JsonStore, Question);
+    test_recall_by_role!(JsonStore, Interview);
 
     #[tokio::test]
     async fn test_load_from_file() {

--- a/storage/src/storage/medium/stub_storage.rs
+++ b/storage/src/storage/medium/stub_storage.rs
@@ -122,13 +122,10 @@ mod test_helper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::property::recall_by_id::test_helper::test_recall_by_id;
-    use crate::storage::recall_by_role::test_helper::test_recall_by_role;
-    use crate::storage::{
-        recall_by_company::test_helper::test_recall_by_company,
-        recall_by_name::test_helper::test_recall_by_name,
-    };
     use crate::test_helper::*;
+    use crate::{
+        test_recall_by_company, test_recall_by_id, test_recall_by_name, test_recall_by_role,
+    };
     use paste::paste;
 
     test_recall_by_id!(StubStore, Company);

--- a/storage/src/storage/medium/stub_storage.rs
+++ b/storage/src/storage/medium/stub_storage.rs
@@ -99,6 +99,7 @@ impl CompanyStore for StubStore<Company> {}
 impl RoleStore for StubStore<Role> {}
 impl FlagStore for StubStore<Flag> {}
 impl QuestionStore for StubStore<Question> {}
+impl ValueStore for StubStore<Value> {}
 
 #[cfg(test)]
 mod test_helper {
@@ -132,12 +133,15 @@ mod tests {
     test_recall_by_id!(StubStore, Company);
     test_recall_by_id!(StubStore, Flag);
     test_recall_by_id!(StubStore, Role);
+    test_recall_by_id!(StubStore, Value);
     test_recall_by_id!(StubStore, Question);
     test_recall_by_name!(StubStore, Company);
     test_recall_by_name!(StubStore, Flag);
     test_recall_by_name!(StubStore, Role);
+    test_recall_by_name!(StubStore, Value);
     test_recall_by_name!(StubStore, Question);
     test_recall_by_company!(StubStore, Flag);
     test_recall_by_company!(StubStore, Role);
+    test_recall_by_company!(StubStore, Value);
     test_recall_by_role!(StubStore, Question);
 }

--- a/storage/src/storage/medium/stub_storage.rs
+++ b/storage/src/storage/medium/stub_storage.rs
@@ -1,8 +1,5 @@
-use crate::prelude::HasDeleted;
-use crate::storable::{Company, Flag, HasCompany, HasId, HasName, Role};
-use crate::storage::{
-    BaseStore, CompanyStore, FlagStore, RecallByCompany, RecallById, RecallByName, RoleStore,
-};
+use crate::storable::*;
+use crate::storage::*;
 use crate::StorageError;
 
 #[derive(Clone)]
@@ -83,9 +80,25 @@ where
     }
 }
 
+impl<T> RecallByRole<T> for StubStore<T>
+where
+    T: HasRole + HasDeleted + Clone,
+{
+    async fn recall_by_role<I: HasId>(&self, role: I) -> anyhow::Result<Vec<T>> {
+        Ok(self
+            .store
+            .iter()
+            .filter(|stored_item| stored_item.get_role_id() == role.get_id())
+            .filter(|item| !item.is_deleted())
+            .cloned()
+            .collect())
+    }
+}
+
 impl CompanyStore for StubStore<Company> {}
 impl RoleStore for StubStore<Role> {}
 impl FlagStore for StubStore<Flag> {}
+impl QuestionStore for StubStore<Question> {}
 
 #[cfg(test)]
 mod test_helper {
@@ -108,6 +121,7 @@ mod test_helper {
 mod tests {
     use super::*;
     use crate::storage::property::recall_by_id::test_helper::test_recall_by_id;
+    use crate::storage::recall_by_role::test_helper::test_recall_by_role;
     use crate::storage::{
         recall_by_company::test_helper::test_recall_by_company,
         recall_by_name::test_helper::test_recall_by_name,
@@ -118,9 +132,12 @@ mod tests {
     test_recall_by_id!(StubStore, Company);
     test_recall_by_id!(StubStore, Flag);
     test_recall_by_id!(StubStore, Role);
+    test_recall_by_id!(StubStore, Question);
     test_recall_by_name!(StubStore, Company);
     test_recall_by_name!(StubStore, Flag);
     test_recall_by_name!(StubStore, Role);
+    test_recall_by_name!(StubStore, Question);
     test_recall_by_company!(StubStore, Flag);
     test_recall_by_company!(StubStore, Role);
+    test_recall_by_role!(StubStore, Question);
 }

--- a/storage/src/storage/medium/stub_storage.rs
+++ b/storage/src/storage/medium/stub_storage.rs
@@ -99,6 +99,7 @@ impl CompanyStore for StubStore<Company> {}
 impl RoleStore for StubStore<Role> {}
 impl FlagStore for StubStore<Flag> {}
 impl QuestionStore for StubStore<Question> {}
+impl InterviewStore for StubStore<Interview> {}
 impl ValueStore for StubStore<Value> {}
 
 #[cfg(test)]
@@ -135,13 +136,16 @@ mod tests {
     test_recall_by_id!(StubStore, Role);
     test_recall_by_id!(StubStore, Value);
     test_recall_by_id!(StubStore, Question);
+    test_recall_by_id!(StubStore, Interview);
     test_recall_by_name!(StubStore, Company);
     test_recall_by_name!(StubStore, Flag);
     test_recall_by_name!(StubStore, Role);
     test_recall_by_name!(StubStore, Value);
     test_recall_by_name!(StubStore, Question);
+    test_recall_by_name!(StubStore, Interview);
     test_recall_by_company!(StubStore, Flag);
     test_recall_by_company!(StubStore, Role);
     test_recall_by_company!(StubStore, Value);
     test_recall_by_role!(StubStore, Question);
+    test_recall_by_role!(StubStore, Interview);
 }

--- a/storage/src/storage/object_storage/flag_store.rs
+++ b/storage/src/storage/object_storage/flag_store.rs
@@ -1,6 +1,5 @@
-use crate::prelude::RecallById;
 use crate::storable::Flag;
-use crate::storage::{BaseStore, RecallByCompany, RecallByName};
+use crate::storage::*;
 
 pub trait FlagStore:
     BaseStore<Flag> + RecallById<Flag> + RecallByName<Flag> + RecallByCompany<Flag>

--- a/storage/src/storage/object_storage/interview_store.rs
+++ b/storage/src/storage/object_storage/interview_store.rs
@@ -1,0 +1,7 @@
+use crate::storable::Interview;
+use crate::storage::*;
+
+pub trait InterviewStore:
+    BaseStore<Interview> + RecallById<Interview> + RecallByName<Interview> + RecallByRole<Interview>
+{
+}

--- a/storage/src/storage/object_storage/mod.rs
+++ b/storage/src/storage/object_storage/mod.rs
@@ -6,3 +6,6 @@ pub use flag_store::*;
 
 mod role_store;
 pub use role_store::*;
+
+mod question_store;
+pub use question_store::*;

--- a/storage/src/storage/object_storage/mod.rs
+++ b/storage/src/storage/object_storage/mod.rs
@@ -7,6 +7,9 @@ pub use flag_store::*;
 mod role_store;
 pub use role_store::*;
 
+mod interview_store;
+pub use interview_store::*;
+
 mod question_store;
 pub use question_store::*;
 

--- a/storage/src/storage/object_storage/mod.rs
+++ b/storage/src/storage/object_storage/mod.rs
@@ -9,3 +9,6 @@ pub use role_store::*;
 
 mod question_store;
 pub use question_store::*;
+
+mod value_store;
+pub use value_store::*;

--- a/storage/src/storage/object_storage/question_store.rs
+++ b/storage/src/storage/object_storage/question_store.rs
@@ -1,0 +1,7 @@
+use crate::storable::Question;
+use crate::storage::*;
+
+pub trait QuestionStore:
+    BaseStore<Question> + RecallById<Question> + RecallByName<Question> + RecallByRole<Question>
+{
+}

--- a/storage/src/storage/object_storage/role_store.rs
+++ b/storage/src/storage/object_storage/role_store.rs
@@ -1,6 +1,5 @@
-use crate::prelude::RecallById;
 use crate::storable::Role;
-use crate::storage::{BaseStore, RecallByCompany, RecallByName};
+use crate::storage::*;
 
 pub trait RoleStore:
     BaseStore<Role> + RecallById<Role> + RecallByName<Role> + RecallByCompany<Role>

--- a/storage/src/storage/object_storage/value_store.rs
+++ b/storage/src/storage/object_storage/value_store.rs
@@ -1,0 +1,7 @@
+use crate::prelude::Value;
+use crate::storage::*;
+
+pub trait ValueStore:
+    BaseStore<Value> + RecallById<Value> + RecallByName<Value> + RecallByCompany<Value>
+{
+}

--- a/storage/src/storage/property/mod.rs
+++ b/storage/src/storage/property/mod.rs
@@ -9,3 +9,6 @@ pub use recall_by_company::RecallByCompany;
 
 pub mod recall_by_name;
 pub use recall_by_name::RecallByName;
+
+pub mod recall_by_role;
+pub use recall_by_role::RecallByRole;

--- a/storage/src/storage/property/recall_by_company.rs
+++ b/storage/src/storage/property/recall_by_company.rs
@@ -10,6 +10,7 @@ where
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_recall_by_company {
         ($storage:ident, $storable:ident) => {
             paste! {
@@ -34,6 +35,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_recall_by_company;
 }

--- a/storage/src/storage/property/recall_by_id.rs
+++ b/storage/src/storage/property/recall_by_id.rs
@@ -1,5 +1,4 @@
-use crate::prelude::HasDeleted;
-use crate::storable::HasId;
+use crate::storable::*;
 use anyhow::Result;
 
 pub trait RecallById<T>

--- a/storage/src/storage/property/recall_by_id.rs
+++ b/storage/src/storage/property/recall_by_id.rs
@@ -36,6 +36,7 @@ mod tests {
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_recall_by_id {
         ($storage:ident, $storable:ident) => {
             paste! {
@@ -59,6 +60,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_recall_by_id;
 }

--- a/storage/src/storage/property/recall_by_name.rs
+++ b/storage/src/storage/property/recall_by_name.rs
@@ -10,6 +10,7 @@ where
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_recall_by_name {
         ($storage:ident, $storable:ident) => {
             paste! {
@@ -34,6 +35,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_recall_by_name;
 }

--- a/storage/src/storage/property/recall_by_name.rs
+++ b/storage/src/storage/property/recall_by_name.rs
@@ -1,5 +1,4 @@
-use crate::prelude::HasDeleted;
-use crate::storable::HasName;
+use crate::storable::*;
 use anyhow::Result;
 
 pub trait RecallByName<T>

--- a/storage/src/storage/property/recall_by_role.rs
+++ b/storage/src/storage/property/recall_by_role.rs
@@ -9,6 +9,7 @@ where
 
 #[cfg(test)]
 pub mod test_helper {
+    #[macro_export]
     macro_rules! test_recall_by_role {
         ($storage:ident, $storable:ident) => {
             paste! {
@@ -33,6 +34,4 @@ pub mod test_helper {
             }
         };
     }
-
-    pub(crate) use test_recall_by_role;
 }

--- a/storage/src/storage/property/recall_by_role.rs
+++ b/storage/src/storage/property/recall_by_role.rs
@@ -1,39 +1,38 @@
-use crate::storable::*;
-use anyhow::Result;
+use crate::storable::{HasDeleted, HasId, HasRole};
 
-pub trait RecallByCompany<T>
+pub trait RecallByRole<T>
 where
-    T: HasCompany + HasDeleted + Clone,
+    T: HasRole + HasDeleted + Clone,
 {
-    async fn recall_by_company<I: HasId>(&self, company_id: I) -> Result<Vec<T>>;
+    async fn recall_by_role<I: HasId>(&self, role: I) -> anyhow::Result<Vec<T>>;
 }
 
 #[cfg(test)]
 pub mod test_helper {
-    macro_rules! test_recall_by_company {
+    macro_rules! test_recall_by_role {
         ($storage:ident, $storable:ident) => {
             paste! {
                 #[tokio::test]
-                async fn [< test_recall_by_company_ $storage:snake _with_ $storable:snake >] () {
+                async fn [< test_recall_by_role_ $storage:snake _with_ $storable:snake >] () {
                     use crate::Timestamp;
 
                     let mut test_subject = $storage::new_test().await.expect("Could not create storage");
                     let mut storable = $storable::new_test().await.expect("Could not create storable");
                     test_subject.store(storable.clone()).await.expect("Could not store storable in storage");
 
-                    let recalled_storable = test_subject.recall_by_company(&storable.get_company_id()).await.expect("Could not recall storable from storage by company id");
+                    let recalled_storable = test_subject.recall_by_role(&storable.get_role_id()).await.expect("Could not recall storable from storage by role id");
                     assert_eq!(recalled_storable.len(), 1);
                     assert!(recalled_storable.contains(&storable));
 
                     storable.date_deleted = Some(Timestamp::now());
                     test_subject.store(storable.clone()).await.expect("Could not store storable in storage");
 
-                    let v: Vec<$storable> = test_subject.recall_by_company(&storable.get_company_id()).await.expect("Could not recall storable from storage by company id");
+                    let v: Vec<$storable> = test_subject.recall_by_role(&storable.get_role_id()).await.expect("Could not recall storable from storage by role id");
                     assert!(v.is_empty());
                 }
             }
         };
     }
 
-    pub(crate) use test_recall_by_company;
+    pub(crate) use test_recall_by_role;
 }


### PR DESCRIPTION
Features:
- Added Storable Objects:
  - Questions
  - Interviews
  - Values
- Made all stores compatible with all new storables
- Added Storable Property HasRole
- Added Storage Property RecallByRole
- Added macros for basic implementation of storage property accessors
- Allow roles to
  - create questions
  - create interviews

Fixes:
- Improved coverage consistency by removing error messages on some unit tests (arguably bug in coverage measurements so opted for reliable coverage over easy error message, though context is still in nearby comment)
- Made Makefile `pre-commit` task behave more like ci workflow
- Normalised how PartialEq works on storables to only compare id and the id of the thing that owns them

Notes
- Code generally feels much more readable and quick to edit
- Concerningly high reliance on macros
- Unsure if `#[macro_export]` is appropriate as it makes it publically accessible from outside the crate, need to check on the best way to scope macros.