### PR TITLE
use ty instead of ident in macro fragment-specifiers

### DIFF
--- a/storage/src/storable/object/flag.rs
+++ b/storage/src/storable/object/flag.rs
@@ -18,7 +18,7 @@ impl FromStr for FlagColor {
         match s.to_lowercase().as_str() {
             "green" => Ok(Self::Green),
             "red" => Ok(Self::Red),
-            _ => Err(format!("Invalid flag_color '{}'", s)),
+            _ => Err(format!("Invalid flag_color '{s}'")),
         }
     }
 }

--- a/storage/src/storable/property/has_company.rs
+++ b/storage/src/storable/property/has_company.rs
@@ -27,7 +27,7 @@ pub(crate) use impl_has_company;
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_company {
-        ($storable:ident) => {
+        ($storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_has_company_ $storable:snake >] () {

--- a/storage/src/storable/property/has_deleted.rs
+++ b/storage/src/storable/property/has_deleted.rs
@@ -24,7 +24,7 @@ pub(crate) use impl_has_deleted;
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_deleted {
-        ($storable:ident) => {
+        ($storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_has_deleted_ $storable:snake >] () {

--- a/storage/src/storable/property/has_id.rs
+++ b/storage/src/storable/property/has_id.rs
@@ -32,9 +32,8 @@ pub(crate) use impl_has_id;
 
 #[cfg(test)]
 pub mod test_helper {
-
     macro_rules! test_has_id {
-        ($storable:ident) => {
+        ($storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_has_id_ $storable:snake >] () {

--- a/storage/src/storable/property/has_name.rs
+++ b/storage/src/storable/property/has_name.rs
@@ -25,7 +25,7 @@ pub(crate) use impl_has_name;
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_name {
-        ($storable:ident) => {
+        ($storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_has_name_ $storable:snake >] () {

--- a/storage/src/storable/property/has_role.rs
+++ b/storage/src/storable/property/has_role.rs
@@ -27,7 +27,7 @@ pub(crate) use impl_has_role;
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_has_role {
-        ($storable:ident) => {
+        ($storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_has_role_ $storable:snake >] () {

--- a/storage/src/storage/property/recall_by_company.rs
+++ b/storage/src/storage/property/recall_by_company.rs
@@ -11,7 +11,7 @@ where
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_recall_by_company {
-        ($storage:ident, $storable:ident) => {
+        ($storage:ty, $storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_recall_by_company_ $storage:snake _with_ $storable:snake >] () {

--- a/storage/src/storage/property/recall_by_id.rs
+++ b/storage/src/storage/property/recall_by_id.rs
@@ -37,7 +37,7 @@ mod tests {
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_recall_by_id {
-        ($storage:ident, $storable:ident) => {
+        ($storage:ty, $storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_recall_by_id_ $storage:snake _with_ $storable:snake >] () {

--- a/storage/src/storage/property/recall_by_name.rs
+++ b/storage/src/storage/property/recall_by_name.rs
@@ -11,7 +11,7 @@ where
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_recall_by_name {
-        ($storage:ident, $storable:ident) => {
+        ($storage:ty, $storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_recall_by_name_ $storage:snake _with_ $storable:snake >] () {

--- a/storage/src/storage/property/recall_by_role.rs
+++ b/storage/src/storage/property/recall_by_role.rs
@@ -10,7 +10,7 @@ where
 #[cfg(test)]
 pub mod test_helper {
     macro_rules! test_recall_by_role {
-        ($storage:ident, $storable:ident) => {
+        ($storage:ty, $storable:ty) => {
             paste! {
                 #[tokio::test]
                 async fn [< test_recall_by_role_ $storage:snake _with_ $storable:snake >] () {

--- a/ui/src/router.rs
+++ b/ui/src/router.rs
@@ -57,7 +57,7 @@ impl fmt::Display for DetailsView {
         match self {
             DetailsView::Company => write!(f, "company"),
             DetailsView::Role => write!(f, "role"),
-            DetailsView::Interview(uuid) => write!(f, "{}", uuid),
+            DetailsView::Interview(uuid) => write!(f, "{uuid}"),
             DetailsView::Questions => write!(f, "questions"),
             DetailsView::Invalid => write!(f, "company"),
         }

--- a/ui/src/views/help.rs
+++ b/ui/src/views/help.rs
@@ -12,7 +12,7 @@ pub fn Help() -> Element {
         async move {
             let logs_result = log_getter.get_logs().await;
             logs_result.unwrap_or_else(|e| {
-                error!("{}", e);
+                error!("{e}");
                 Vec::with_capacity(0)
             })
         }
@@ -40,7 +40,7 @@ pub fn Help() -> Element {
                 onclick: move |_| {
                     let log_clearer = log_cleaner.clone();
                     spawn(async move {
-                        log_clearer.clear_logs().await.unwrap_or_else(|e| error!("{}", e));
+                        log_clearer.clear_logs().await.unwrap_or_else(|e| error!("{e}"));
                     });
                     logs_resource.restart();
                 },


### PR DESCRIPTION
Conceptually the thing we're targeting is a type, not an ideant and this will let us use paths, which ident won't