### PR TITLE
chore: update dependencies, dependabot got stuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6391,6 +6391,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"


### PR DESCRIPTION
Looks like the Windows build problem is related to the same icons issue found in Dioxus 0.7.2 and 0.7.3. We can go backwards if we need.